### PR TITLE
Correct misspelling of architectures library.properties field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=This is an Arduino Library for the AS3935 Lightning Detector by ASM
 paragraph=This library adds both I-squared-C and SPI functionality for the <a href="https://www.sparkfun.com/products/15276" SparkFun AS3935 Lightning Detector</a>. The provided example walks you through basic functionality through more advanced features like tuning the resonance frequency of the antenna. 
 category=Sensors
 url=https://github.com/sparkfun/SparkFun_AS3935_Lightning_Detector_Arduino_Library
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format