### PR TITLE
Constructor uses SF_AS3935_I2C_ADDRESS instead of int

### DIFF
--- a/src/SparkFun_AS3935.cpp
+++ b/src/SparkFun_AS3935.cpp
@@ -15,7 +15,7 @@
 SparkFun_AS3935::SparkFun_AS3935() { }
 
 // Another constructor with I2C but receives address from user.  
-SparkFun_AS3935::SparkFun_AS3935(int address) { _address = address; }
+SparkFun_AS3935::SparkFun_AS3935(enum SF_AS3935_I2C_ADDRESS address) { _address = address; }
 
 bool SparkFun_AS3935::begin( TwoWire &wirePort )
 {

--- a/src/SparkFun_AS3935.h
+++ b/src/SparkFun_AS3935.h
@@ -74,7 +74,7 @@ class SparkFun_AS3935
     SparkFun_AS3935();
 
     // Constructor to be used with I-squared-C. 
-    SparkFun_AS3935(int address);
+    SparkFun_AS3935(enum SF_AS3935_I2C_ADDRESS address);
 
     // I-squared-C Begin
     bool begin(TwoWire &wirePort = Wire);


### PR DESCRIPTION
When using PlatformIO to build, it produces a warning for the constructor because it is trying to implicitly convert an `int` (the `address` parameter) to `enum SF_AS3935_I2C_ADDRESS` (the `_address` member variable).  To fix the warning, I chose to change the type of the constructor's parameter to be `enum SF_AS3935_I2C_ADDRESS`.  I think that makes it more explicit which addresses are allowed.  Alternatively, the `_address` member could have been changed to type `int`.