### PR TITLE
Fix watchdogThreshold and noiseLevel

### DIFF
--- a/src/SparkFun_AS3935.cpp
+++ b/src/SparkFun_AS3935.cpp
@@ -117,8 +117,7 @@ void SparkFun_AS3935::watchdogThreshold( uint8_t _sensitivity )
 {
   if( (_sensitivity < 1) || (_sensitivity > 10) )// 10 is the max sensitivity setting
     return; 
-
-  writeRegister(THRESHOLD, GAIN_MASK, _sensitivity, 0); 
+  writeRegister(THRESHOLD, THRESH_MASK, _sensitivity, 0);
 }
 
 // REG0x01, bits[3:0], manufacturer default: 0010 (2). 
@@ -126,9 +125,8 @@ void SparkFun_AS3935::watchdogThreshold( uint8_t _sensitivity )
 // IRQ Pin.  
 uint8_t SparkFun_AS3935::readWatchdogThreshold(){
 
-  uint8_t regVal = readRegister(THRESHOLD); 
-  return (regVal &= (~THRESH_MASK));
-
+  uint8_t regVal = readRegister(THRESHOLD);
+  return (regVal & THRESH_MASK);
 }
 
 // REG0x01, bits [6:4], manufacturer default: 010 (2).
@@ -141,7 +139,7 @@ void SparkFun_AS3935::setNoiseLevel( uint8_t _floor )
   if( (_floor < 1) || (_floor > 7) )
     return; 
   
-  writeRegister(THRESHOLD, FLOOR_MASK, _floor, 4); 
+  writeRegister(THRESHOLD, NOISE_FLOOR_MASK, _floor, 4); 
 }
 
 // REG0x01, bits [6:4], manufacturer default: 010 (2).
@@ -149,7 +147,7 @@ void SparkFun_AS3935::setNoiseLevel( uint8_t _floor )
 uint8_t SparkFun_AS3935::readNoiseLevel(){
 
   uint8_t regVal = readRegister(THRESHOLD);
-  return ((regVal &= (~NOISE_MASK)) >> 4);
+  return ((regVal & NOISE_FLOOR_MASK) >> 4);
 
 }
 

--- a/src/SparkFun_AS3935.h
+++ b/src/SparkFun_AS3935.h
@@ -32,17 +32,16 @@ enum SF_AS3935_REGSTER_MASKS {
   IO_MASK           = 0xC1,
   DISTANCE_MASK     = 0xC0,
   INT_MASK          = 0xF0, 
-  THRESH_MASK       = 0xF0, 
+  THRESH_MASK       = 0x0F, 
   R_SPIKE_MASK      = 0xF0, 
   ENERGY_MASK       = 0xF0, 
   CAP_MASK          = 0xF0, 
   LIGHT_MASK        = 0xCF, 
   DISTURB_MASK      = 0xDF, 
-  FLOOR_MASK        = 0x07,
+  NOISE_FLOOR_MASK  = 0x70,
   OSC_MASK          = 0xE0,
   SPI_READ_M        = 0x40,
   CALIB_MASK        = 0x7F,
-  NOISE_MASK        = 0x8F,
   DIV_MASK          = 0x3F
 
 };


### PR DESCRIPTION
The mask for getting and setting the noise floor was wrong.  There were actually
two masks.  Replaced them with a single mask, NOISE_FLOOR_MASK, that has 1 bits
where the noise floor field is within the register.

Setting the watchdogThreshold was using the wrong mask.  Inverted THRESH_MASK
so it has 1 bits where the watchdog field is within the register (you don't
need to invert it when using it in the code).