### PR TITLE
Fixed issues with CAP_MASK and getTuneCap()

### DIFF
--- a/src/SparkFun_AS3935.cpp
+++ b/src/SparkFun_AS3935.cpp
@@ -374,7 +374,7 @@ void SparkFun_AS3935::tuneCap(uint8_t _farad)
 uint8_t SparkFun_AS3935::readTuneCap(){
 
   uint8_t regVal = readRegister(FREQ_DISP_IRQ);
-  return ((regVal &= (~CAP_MASK)) * 8); //Multiplied by 8pF
+  return ((regVal &= CAP_MASK) * 8); //Multiplied by 8pF
 
 }
 

--- a/src/SparkFun_AS3935.h
+++ b/src/SparkFun_AS3935.h
@@ -41,7 +41,7 @@ enum SF_AS3935_REGSTER_MASKS {
   THRESH_MASK       = 0x0F, 
   R_SPIKE_MASK      = 0xF0, 
   ENERGY_MASK       = 0xF0, 
-  CAP_MASK          = 0xF0, 
+  CAP_MASK          = 0x0F, 
   LIGHT_MASK        = 0xCF, 
   DISTURB_MASK      = 0xDF, 
   NOISE_FLOOR_MASK  = 0x70,


### PR DESCRIPTION
These two changes address the problem with tuneCap() and readTuneCap().  In SparkFun_AS3935.h the constant CAP_MASK is changed to match the register mapping in the data sheet for register 0x08.  In SparkFun_AS3935.cpp the logic is changed so the register value is Anded with the positive mask (not with the negation of the mask).  